### PR TITLE
Skip empty cells when unfolding ranges

### DIFF
--- a/src/table-evaluator.ts
+++ b/src/table-evaluator.ts
@@ -338,7 +338,7 @@ export class TableEvaluator {
     }
 
 
-    getValueByCoordinates(row: number, col: number) {
+    getValueByCoordinates(row: number, col: number, nullAsZero: boolean = true) {
         const r = this.cords2ref(row, col);
         this.debug(`getValueByCoordinates ${r}`);
 
@@ -346,7 +346,7 @@ export class TableEvaluator {
             this.debug(`getValueByCoordinates giving the value ${this.tableData[row][col]}`);
             const val = this.tableData[row][col];
 
-            if (val === null) return 0;
+            if (val === null) return nullAsZero ? 0 : null;
 
             // Handle unit values
             if (typeof val === "string") {
@@ -775,10 +775,13 @@ try {
                 this.parents[formulaRow][formulaCol].push([r, c]);
                 this.children[r][c].push([formulaRow, formulaCol]);
 
-                const val = this.getValueByCoordinates(r, c);
+                const val = this.getValueByCoordinates(r, c, false);
 
-                // For null values in matrices, use 0 to maintain matrix structure
-                //const matrixVal = val === null ? "null" : val;
+                // Only remove empty cells from ranges, not matrix (it would change the shape)
+                if (!matrix && val === null) { // Maybe skip configurable placeholders too? like settings.nullValues/skip = [null, "?","n/a"]
+                    continue;
+                }
+
                 colArray.push(val);
             }
             rowArray.push(colArray);


### PR DESCRIPTION
This PR removes empty cells from ranges when expanding them. This allows mainly statistical functions to work as expected. Cells that do contain a 0 are preserved, of course. Matrices are also unaffected by this change because they would change shape.

I have not found any formula that would suffer from my changes, but maybe I lack imagination? If such case exist, it can be fixed by manually typing 0 in the empty cells, or by adding a setting to control my new behavior.

<img width="1047" height="674" alt="image" src="https://github.com/user-attachments/assets/4f424c09-2ab9-4a16-8419-df6b5d06e83e" />

I've considered a few other options to achieve the behavior I was looking for:
- Introduce a new range syntax to filter empty cells instead, eg `a1::a7` or `FILTER(a1:a7)` but ultimately modifying the regular syntax doesn't seem to have any downsides.
- Leave the empty cells as zero most of the time, as currently, but filter them for statistical functions. This is difficult because ranges are expanded long before function evaluation. It's certainly possible, however.
- Remove the entire nullAsZero thing, and leave empty cells be null. Then patch/overload mathjs so that it can decide itself when to convert null to 0 and when to skip null. This is probably the most "correct" way but it's also complicated and seemed overkill.

Other notes:
- The `sum` wrapper was already mostly unnecessary since you added null as zero, but with this PR the wrapper is now entirely redundant and could be removed. I did not do it now because I wanted to keep this PR as small as possible.
- It would be interesting to also ignore cells that contain random text, like spreadsheets do. But at this time it's difficult to know for sure what is or isn't valid at unfolding time. A regex to allow all number formats + units might be "good enough", however. The main benefit would be to be able to put placeholders instead of having empty cells, eg "?" or "N/A" or "Unknown".
- If a range is entirely empty cells, `=median(a1:b7)` will return an error. This is how it works in spreadsheets too. But if, you prefer, I can create a 3 lines wrapper to enhance some functions and allow them to return 0 when they receive an empty range (sum/median/mean/min/max might make sense).