### PR TITLE
Fix row labels disappear when cells selected

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -378,10 +378,9 @@ export default class CalcCraftPlugin extends Plugin {
         // Label ALL rows (both thead and tbody)
         const allRows = Array.from(tableEl.rows);
         allRows.forEach((row, rowIndex) => {
-            const firstCell = row.cells[0];
-            if (firstCell && !firstCell.dataset.rowLabeled) {
-                firstCell.dataset.rowLabeled = 'true';
-                firstCell.dataset.rowNumber = String(rowIndex + 1);
+            if (!row.dataset.rowLabeled) {
+                row.dataset.rowLabeled = 'true';
+                row.dataset.rowNumber = String(rowIndex + 1);
             }
         });
     }

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,3 @@
-/* For column headers */
-th::before {
-    content: attr(data-col-label);
-    position: absolute;
-    font-size: smaller;
-    color: gray;
-    transform: translate(0px, -12px); 
-}
-
-/* For row headers for td */
-tr td:first-child::before {
-    content: attr(data-row-label);
-    position: absolute;
-    font-size: smaller;
-    color: gray;
-    #background-color:white;
-    transform: translate(-16px, 0px);  
-}
-
-
 /**********formula cell************/
 /*light theme*/
 .markdown-rendered .formula-cell-borderenabled {
@@ -184,21 +164,22 @@ vertical-align: middle;
     color: var(--CalcCraft_formula_font_children_dark);
 }
 
-/* Make table cells position relative for absolute positioning of labels */
-table th,
-table td {
-    position: relative;
-}
-
 /* Add padding to table to make room for labels */
-table {
-    margin-left: 25px;
+.cm-table-widget table {
+    margin-left: 20px;
     margin-top: 20px;
 }
 
+/* Make table cells position relative for absolute positioning of labels */
+.cm-table-widget table th,
+.cm-table-widget table td,
+.cm-table-widget table tr {
+    position: relative;
+}
+
 /* Column labels - display above th/td elements */
-th[data-col-letter]::before,
-td[data-col-letter]::before {
+.cm-table-widget th[data-col-letter]::before,
+.cm-table-widget td[data-col-letter]::before {
     content: attr(data-col-letter);
     position: absolute;
     top: -18px;
@@ -213,10 +194,10 @@ td[data-col-letter]::before {
 }
 
 /* Row labels - display to the left of first cell in each row */
-tr[data-row-number]::before {
+.cm-table-widget tr[data-row-number]::before {
     content: attr(data-row-number);
     position: absolute;
-    left: 0px;
+    left: -25px;
     margin-top: 1em;
     font-size: 0.75em;
     color: var(--text-muted);

--- a/styles.css
+++ b/styles.css
@@ -213,13 +213,11 @@ td[data-col-letter]::before {
 }
 
 /* Row labels - display to the left of first cell in each row */
-tr th:first-child[data-row-number]::after,
-tr td:first-child[data-row-number]::after {
+tr[data-row-number]::before {
     content: attr(data-row-number);
     position: absolute;
-    left: -25px;
-    top: 50%;
-    #transform: translateY(-50%);
+    left: 0px;
+    margin-top: 1em;
     font-size: 0.75em;
     color: var(--text-muted);
     font-weight: normal;


### PR DESCRIPTION
This fixes the issue where row labels disappeared when the leftmost cell was highlighted. This was caused by the highlight rectangle overriding calccraft's `td .. ::before`. I didn't see a straightforward way to make them both co-exist so I moved the label to the `tr` instead.

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/1867e2e6-f572-4e51-a7ce-1a628a128e49" />

This PR also hides the labels in reader mode. The labels were already not visible in reader mode but it relied on chance. I've added the `cm-table-widget` class to make it explicit and it also avoids adding needless margins